### PR TITLE
Syntax fix for example docker-compose.yml file

### DIFF
--- a/elkarbackup/1.3/README.md
+++ b/elkarbackup/1.3/README.md
@@ -39,7 +39,7 @@ services:
     environment:
       SYMFONY__DATABASE__PASSWORD: "your-password-here"
       EB_CRON: "enabled"
-      volumes:
+    volumes:
       - backups:/app/backups
       - uploads:/app/uploads
       - sshkeys:/app/.ssh


### PR DESCRIPTION
Volumes section need to be child of the service, not the environment